### PR TITLE
Update Match the Tiles scoring policy

### DIFF
--- a/lib/screens/memorygameapp.dart
+++ b/lib/screens/memorygameapp.dart
@@ -201,11 +201,11 @@ class _MemoryGameScreenState extends State<MemoryGameScreen> {
         setState(() {
           items.remove(first);
           items.remove(second);
+          score += 10;
         });
 
         if (items.isEmpty) {
           setState(() {
-            score += 10;
           });
           Future.delayed(const Duration(milliseconds: 500), () {
             _showCompletionDialog();


### PR DESCRIPTION
Changed scoring policy in lib/screens/memorygameapp.dart
Old: +10 points only when all tiles matched correctly
New: +10 points per correct pair